### PR TITLE
CVE-2020-14001 Unintended read access in kramdown gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     hashie (3.5.6)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    kramdown (1.16.2)
+    kramdown (2.3.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)


### PR DESCRIPTION
# [CVE-2020-14001](https://nvd.nist.gov/vuln/detail/CVE-2020-14001)
The kramdown gem before 2.3.0 for Ruby processes the template option inside Kramdown documents by default, which allows unintended read access (such as template="/etc/passwd") or unintended embedded Ruby code execution (such as a string that begins with template="string://<%= `). NOTE: kramdown is used in Jekyll, GitLab Pages, GitHub Pages, and Thredded Forum.

on kramdown in [Gemfile.lock](https://github.com/gojek/gojek/blob/-/Gemfile.lock).
upgrade kramdown to version 2.3.1
