### PR TITLE
CVE-2020-8165 Unintended unmarshalling in ActiveSupport 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.6)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)


### PR DESCRIPTION
# [CVE-2020-8165](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8165)

update ``activesupport`` in [Gemfile.lock](https://github.com/gojek/gojek/blob/-/Gemfile.lock).
```json
gem "activesupport", ">= 5.2.4.3"
```
In ActiveSupport, there is potentially unexpected behaviour in the MemCacheStore and RedisCacheStore where, when
untrusted user input is written to the cache store using the ``raw: true`` parameter, re-reading the result
from the cache can evaluate the user input as a Marshalled object instead of plain text. Vulnerable code looks like:
```
data = cache.fetch("demo", raw: true) { untrusted_string }
```
Versions Affected: rails < 5.2.5, rails < 6.0.4
Not affected: Applications not using MemCacheStore or RedisCacheStore. Applications that do not use the ``raw`` option when storing untrusted user input.
Fixed Versions: rails >= 5.2.4.3, rails >= 6.0.3.1

## Impact
Unmarshalling of untrusted user input can have impact up to and including RCE. At a minimum,
this vulnerability allows an attacker to inject untrusted Ruby objects into a web application.
In addition to upgrading to the latest versions of Rails, developers should ensure that whenever
they are calling ``Rails.cache.fetch`` they are using consistent values of the raw parameter for both
reading and writing, especially in the case of the RedisCacheStore which does not, prior to these changes,
detect if data was serialized using the ``raw`` option upon deserialization.

## Workarounds
It is recommended that application developers apply the suggested patch or upgrade to the latest release as
soon as possible. If this is not possible, we recommend ensuring that all user-provided strings cached using
the ``raw`` argument should be double-checked to ensure that they conform to the expected format.